### PR TITLE
Fix empty password being passed to register() func

### DIFF
--- a/src/pages/auth/index.vue
+++ b/src/pages/auth/index.vue
@@ -212,7 +212,7 @@ export default Vue.extend({
 						id: this.id,
 						name: this.name,
 						email: this.email,
-						password: ``,
+						password: this.password,
 						bio: `Default bio.`,
 						location: ``,
 						posts: [],
@@ -230,6 +230,7 @@ export default Vue.extend({
 					const peerIDPublicKey = peerID.publicKey
 					const _res = await this.$register(account, peerIDPrivateKey, peerIDPublicKey)
 					console.log(_res)
+					account.password = ``
 					this.$sendProfile(account).then((cid) => {
 						account.cid = cid
 						this.changeCID(cid)


### PR DESCRIPTION
`password` field in `account` object was previously set to an empty string in order to avoid publishing plaintext password to IPFS. This resulted in empty password being passed to `register()` function and subsequently to `getEncryptedPeerIDPrivateKey()` function. 
This pull request resolves the bug. 