### PR TITLE
Resolve conflicting indentation rule

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,8 +2,7 @@
 root = true
 
 [*]
-indent_style = space
-indent_size = 2
+indent_style = tab
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true


### PR DESCRIPTION
Indentation rule is set to "tab" in .eslintrc.js. This commit ensures .editorconfig is also consistent with the same rule