### PR TITLE
Reset state properly after logging out

### DIFF
--- a/src/store/session.ts
+++ b/src/store/session.ts
@@ -64,25 +64,14 @@ export const mutations: MutationTree<Profile> = {
 		state.posts.push(newPost)
 	},
 	[MutationType.LOGOUT]: (state) => {
-		// eslint-disable-next-line
-		state = {
-			cid: ``,
-			id: ``,
-			name: ``,
-			email: ``,
-			password: ``,
-			bio: `Default bio.`,
-			location: ``,
-			posts: [],
-			reposts: [],
-			socials: [],
-			bookmarks: [],
-			categories: [],
-			followers: [],
-			following: [],
-			avatar: ``,
-			comments: [],
-		}
+		state.cid = ``
+		state.id = ``
+		state.name = ``
+		state.email = ``
+		state.avatar = ``
+		state.bio = `Default bio.`
+		state.location = ``
+		state.posts = []
 	},
 }
 


### PR DESCRIPTION
Profile state is not properly reset on clicking the "logout" button. 

To replicate the bug: 
1. Register on capsule-vue app
2. Click on Log Out button
3. Without refreshing the page, click on "Get Started" button again. You will be redirected directly inside the app instead of the auth page. You will also be able to see any posts you may have published, your edited profile etc. This behaviour indicates that profile state was not reset properly. 

The bug was caused due to incorrect handling of JS objects as function parameters. This PR attempts to resolve the bug. 