### PR TITLE
[fix] Use authorID instead of authorCID to fetch profile.

### DIFF
--- a/src/components/AuthorCard.vue
+++ b/src/components/AuthorCard.vue
@@ -10,7 +10,7 @@
 
 			<div class="mx-4">
 				<h6 class="text-sm uppercase text-lightSecondaryText">written by:</h6>
-				<nuxt-link :to="'/' + this.$props.authorCID" class="text-2xl">
+				<nuxt-link :to="'/' + this.$props.authorID" class="text-2xl">
 					{{ this.$props.authorName }}
 				</nuxt-link>
 				<p
@@ -22,7 +22,7 @@
 			</div>
 		</div>
 		<div>
-			<FriendButton class="justify-self-end" :authorID="this.$props.authorCID" :showIcons="true" />
+			<FriendButton class="justify-self-end" :authorID="this.$props.authorID" :showIcons="true" />
 		</div>
 	</div>
 </template>

--- a/src/pages/post/_post.vue
+++ b/src/pages/post/_post.vue
@@ -152,7 +152,7 @@
 				</div>
 				<PostActions
 					:post="this.post"
-					:authorID="this.post.authorCID"
+					:authorID="this.post.authorID"
 					:isCommenting="true"
 					:tags="this.post.tags"
 					:filter="this.filter"


### PR DESCRIPTION
Eventually this authorID should point to the NEAR ID (eg:
christos@capsule.near - or capsule.social if top level ids are possible)

This partially fixes broken profiles (user posts are loading from orbit) and prepares for migrating profiles to NEAR.