### PR TITLE
[Fix] Remove posts from tag interface

### DIFF
--- a/src/components/post/Editor.vue
+++ b/src/components/post/Editor.vue
@@ -311,7 +311,6 @@ export default Vue.extend({
 			} else {
 				const t: Tag = {
 					name: this.tag,
-					posts: ``,
 				}
 				this.$store.commit(`draft/addTag`, t)
 				this.tag = ``

--- a/src/interfaces/Tag.ts
+++ b/src/interfaces/Tag.ts
@@ -1,4 +1,3 @@
 export interface Tag {
 	name: string
-	posts: string[] | string
 }


### PR DESCRIPTION
Just a simple change, the `posts` field is totally redundant.