### PR TITLE
Set public key in session state after login/signup

### DIFF
--- a/src/pages/auth/index.vue
+++ b/src/pages/auth/index.vue
@@ -220,6 +220,7 @@ export default Vue.extend({
 			changeBio: MutationType.CHANGE_BIO,
 			changeLocation: MutationType.CHANGE_LOCATION,
 			appendPostCID: MutationType.APPEND_POSTCID,
+			changePublicKey: MutationType.CHANGE_PUBLICKEY,
 		}),
 		toggleFormType() {
 			this.isLogin = !this.isLogin
@@ -253,6 +254,7 @@ export default Vue.extend({
 					for (const postcid of account.posts) {
 						this.appendPostCID(postcid)
 					}
+					this.changePublicKey(account.publicKey)
 					this.$router.push(`/settings`)
 				} else {
 					alert(`Authentication failed!`)
@@ -284,6 +286,7 @@ export default Vue.extend({
 						this.changeID(this.id)
 						this.changeName(this.name)
 						this.changeEmail(this.email)
+						this.changePublicKey(account.publicKey)
 						this.$router.push(`/settings`)
 					} else {
 						alert(`Registration Unsuccessful!`)

--- a/src/store/session.ts
+++ b/src/store/session.ts
@@ -34,6 +34,7 @@ export const MutationType = {
 	APPEND_POSTCID: `appendPostCID`,
 	CHANGE_NAME: `updateName`,
 	CHANGE_EMAIL: `updateEmail`,
+	CHANGE_PUBLICKEY: `changePublicKey`,
 	CHANGE_AVATAR: `updateAvatar`,
 	CHANGE_BIO: `updateBio`,
 	CHANGE_LOCATION: `updateLocation`,
@@ -55,6 +56,9 @@ export const mutations: MutationTree<Session> = {
 	},
 	[MutationType.CHANGE_EMAIL]: (state, newEmail: string) => {
 		state.email = newEmail
+	},
+	[MutationType.CHANGE_PUBLICKEY]: (state, publickey: string) => {
+		state.publicKey = publickey
 	},
 	[MutationType.CHANGE_AVATAR]: (state, newAvatar: string) => {
 		state.avatar = newAvatar


### PR DESCRIPTION
Need to set the public key after login/signup in order to avoid overwriting profile data stored in NEAR