### PR TITLE
Do not reverse reposts array on retrieval

### DIFF
--- a/src/pages/_id/reposts.vue
+++ b/src/pages/_id/reposts.vue
@@ -57,7 +57,6 @@ export default Vue.extend({
 				this.reposts.push(res[i].post)
 			}
 		}
-		this.reposts.reverse()
 		getFollowersAndFollowing(this.$store.state.session.id).then(({ following }) => {
 			this.following = following
 		})


### PR DESCRIPTION
Now that we sort reposts in the backend (See https://github.com/capsulesocial/capsule-orbit/pull/101), there's no need to reverse reposts array on retrieval. 

Some more context: This change is specific to the Reposts section in the profile page, where a call is made to backend on `/repost?authorID=tom&sort=NEW` endpoint. `sort=NEW` didn't have any effect on the results from backend earlier. Now it does. 