### PR TITLE
Update call to NEAR JSON RPC provider

### DIFF
--- a/src/backend/near.ts
+++ b/src/backend/near.ts
@@ -35,7 +35,7 @@ function getRpcProviderUrl() {
 	}
 }
 
-const provider = new providers.JsonRpcProvider(getRpcProviderUrl())
+const provider = new providers.JsonRpcProvider({ url: getRpcProviderUrl() })
 
 export async function getUsernameNEAR(accountId: string): Promise<string | null> {
 	const rawResult = await provider.query({


### PR DESCRIPTION
near-api-js introduced a feature that allows passing of API keys when sending requests to custom RPC server. As a result they deprecated passing the url directly to `JsonRpcProvider`