### PR TITLE
fix some open items + feedbacks of Tess and Aimee

### DIFF
--- a/src/assets/css/quill.css
+++ b/src/assets/css/quill.css
@@ -690,7 +690,9 @@
 	overflow: visible;
 }
 .ql-bubble .ql-editor img {
-	max-width: 100%;
+	max-width: 95%;
+	margin: auto;
+	border-radius: 0.5rem;
 }
 .ql-bubble .ql-picker {
 	color: #ccc;

--- a/src/components/post/Actions.vue
+++ b/src/components/post/Actions.vue
@@ -31,7 +31,7 @@
 			<!-- Comments Activity -->
 			<div class="flex h-48 justify-between border-b">
 				<!-- Graph breakdown -->
-				<div class="ml-5 hidden h-full flex-row self-end xl:flex">
+				<div class="ml-5 pt-4 hidden h-full flex-row self-end xl:flex">
 					<!-- Positive -->
 					<span
 						class="bg-positive w-6 self-end rounded-t-full"
@@ -99,7 +99,7 @@
 			</div>
 		</article>
 		<!-- Post a Comment -->
-		<article v-show="!toggleStats" id="section" class="xl:pb-5">
+		<article v-show="!toggleStats" id="section">
 			<div class="flex w-full justify-between py-5">
 				<div class="flex flex-row items-center">
 					<span class="pr-2 font-semibold">{{ getCommentCount(`total`) }} comments</span>
@@ -320,6 +320,9 @@
 				:cid="c._id"
 				:timestamp="c.timestamp"
 			/>
+			<div v-if="comments.length === 0 && filter !== ``" class="text-gray5 pt-5 text-sm text-center">
+				No comments under this filter
+			</div>
 		</article>
 	</section>
 </template>

--- a/src/components/post/Card.vue
+++ b/src/components/post/Card.vue
@@ -10,7 +10,7 @@
 				style="backdrop-filter: blur(10px)"
 			>
 				<div
-					class="from-lightBGStart to-lightBGStop sticky top-0 z-20 border-b bg-gradient-to-r px-4 py-4 xl:px-6 xl:py-5"
+					class="from-lightBGStart to-lightBGStop sticky top-0 z-40 border-b bg-gradient-to-r px-4 py-4 xl:px-6 xl:py-5"
 					style="backdrop-filter: blur(10px)"
 				>
 					<!-- Show Quote Repost input -->
@@ -34,7 +34,7 @@
 						<!-- Simple repost -->
 						<div
 							v-if="repostedBy !== `` && !hideRepostIcon && quote === null"
-							class="text-gray5 -mt-2 mb-4 flex w-full items-center pt-2 xl:mb-2"
+							class="text-gray5 -mt-2 mb-4 flex w-full items-center pt-2 xl:mb-3"
 						>
 							<RepostIcon class="hidden xl:block" style="width: 15px; height: 15px" :shrink="true" />
 							<p class="text-gray5 hidden pl-2 text-sm xl:block">
@@ -140,7 +140,7 @@
 						<!-- Content -->
 						<div class="mt-4 hidden flex-col justify-between xl:flex xl:flex-row">
 							<!-- Left side: Title, subtitle / preview, tags -->
-							<div class="mr-4">
+							<div class="mr-4 w-full">
 								<nuxt-link :to="'/post/' + postCID">
 									<div class="flex max-w-full flex-col overflow-hidden pr-4">
 										<h3 class="break-words pb-2 text-lg font-semibold">
@@ -282,7 +282,7 @@
 						<!-- Simple repost -->
 						<div
 							v-if="repostedBy !== `` && !hideRepostIcon && quote === null"
-							class="text-gray5 -mt-2 mb-2 flex w-full items-center pt-2"
+							class="text-gray5 -mt-2 mb-3 flex w-full items-center pt-2"
 						>
 							<RepostIcon :shrink="true" />
 							<p class="text-gray5 pl-2 text-sm">
@@ -377,7 +377,7 @@
 						<!-- Content -->
 						<div class="mt-4 flex flex-col justify-between xl:flex-row">
 							<!-- Left side: Title, subtitle / preview, tags -->
-							<div class="mr-4 flex flex-col justify-between">
+							<div class="mr-4 flex w-full flex-col justify-between">
 								<nuxt-link :to="'/post/' + postCID">
 									<div class="flex max-w-full flex-col overflow-hidden pr-4">
 										<h3 class="break-words pb-2 text-lg font-semibold">

--- a/src/components/post/Editor.vue
+++ b/src/components/post/Editor.vue
@@ -252,7 +252,7 @@ export default Vue.extend({
 			if (line[1] === 0 && line[0].domNode.innerHTML === `<br>`) {
 				this.toggleAddContent = true
 				if (index === 0) {
-					this.addContentPosTop = pos.top + 40
+					this.addContentPosTop = pos.top + 50
 					this.addContentPosLeft = pos.left
 				} else {
 					this.addContentPosTop = pos.top

--- a/src/layouts/settings.vue
+++ b/src/layouts/settings.vue
@@ -45,13 +45,13 @@
 								>
 									Confidentiality and Security
 								</nuxt-link> -->
-								<nuxt-link
+								<!-- <nuxt-link
 									:class="$route.name === `settings-network` ? `bg-lightInput font-semibold` : ``"
 									class="text-gray5 focus:outline-none mb-4 w-full rounded-lg py-2 px-4 text-left"
 									to="/settings/network"
 								>
 									Nodes and Network
-								</nuxt-link>
+								</nuxt-link> -->
 								<nuxt-link
 									to="/settings/styling"
 									:class="$route.name === `settings-styling` ? `bg-lightInput font-semibold` : ``"

--- a/src/pages/discover/_category.vue
+++ b/src/pages/discover/_category.vue
@@ -153,7 +153,7 @@ export default Vue.extend({
 	mounted() {
 		const container = document.getElementById(`column`)
 		if (container) {
-			container.addEventListener(`scroll`, this.handleScrollHeader)
+			container.addEventListener(`scroll`, this.handleScrollHeader, true)
 		}
 	},
 	methods: {
@@ -169,7 +169,9 @@ export default Vue.extend({
 			this.isLoading = false
 			// No more posts
 			if (posts.length < this.limit) {
-				this.noMorePosts = true
+				if (posts.length > 0) {
+					this.noMorePosts = true
+				}
 				const container = document.getElementById(`column`)
 				if (container) {
 					container.removeEventListener(`scroll`, this.handleScrollHeader)
@@ -220,7 +222,7 @@ export default Vue.extend({
 			}
 			this.padding = header?.clientHeight
 			const currentScroll = body.scrollTop
-			if (body.scrollTop <= 0) {
+			if (body.scrollTop <= 0 && this.scrollDown === false) {
 				header.classList.remove(scrollUp)
 				buttontitle.classList.remove(opacity0)
 				buttonbg.classList.remove(opacity0)

--- a/src/pages/settings/index.vue
+++ b/src/pages/settings/index.vue
@@ -14,20 +14,20 @@
 				<span class="bg-gray1 rounded-full p-1"><ChevronRight /></span>
 			</nuxt-link>
 			<!-- <nuxt-link
-									:class="$route.name === `settings-security` ? `bg-lightInput font-semibold` : ``"
-									class="w-full rounded-lg text-gray5 py-2 px-4 mb-4 text-left focus:outline-none"
-									to="/settings/security"
-								>
-									Confidentiality and Security
-								</nuxt-link> -->
-			<nuxt-link
+				:class="$route.name === `settings-security` ? `bg-lightInput font-semibold` : ``"
+				class="w-full rounded-lg text-gray5 py-2 px-4 mb-4 text-left focus:outline-none"
+				to="/settings/security"
+			>
+				Confidentiality and Security
+			</nuxt-link> -->
+			<!-- <nuxt-link
 				:class="$route.name === `settings-network` ? `bg-lightInput font-semibold` : ``"
 				class="text-gray5 focus:outline-none mb-4 flex w-full items-center justify-between rounded-lg py-2 px-4 text-left"
 				to="/settings/network"
 			>
 				<h6>Nodes and Network</h6>
 				<span class="bg-gray1 rounded-full p-1"><ChevronRight /></span>
-			</nuxt-link>
+			</nuxt-link> -->
 			<nuxt-link
 				to="/settings/styling"
 				:class="$route.name === `settings-styling` ? `bg-lightInput font-semibold` : ``"

--- a/src/pages/tag/_tag.vue
+++ b/src/pages/tag/_tag.vue
@@ -12,7 +12,10 @@
 		</div>
 		<!-- Posts loaded -->
 		<div ref="container" class="xl:w-750 min-h-130 h-130 xl:min-h-150 xl:h-150 fixed w-full overflow-y-auto">
-			<article v-if="posts.length == 0" class="mt-36 grid justify-items-center overflow-y-hidden px-6 xl:px-0">
+			<article
+				v-if="posts.length == 0 && !isLoading"
+				class="mt-36 grid justify-items-center overflow-y-hidden px-6 xl:px-0"
+			>
 				<p class="text-gray5 align-end mb-5 flex items-end text-sm" style="max-width: 366px">
 					It seems there are no posts under this topic yet
 				</p>
@@ -40,7 +43,7 @@
 			</p>
 		</div>
 		<!-- Not loaded yet -->
-		<article v-show="isLoading" class="flex w-full justify-center">
+		<article v-show="isLoading" class="flex w-full justify-center mt-12">
 			<div class="loader modal-animation m-6"></div>
 		</article>
 	</section>
@@ -126,7 +129,7 @@ export default Vue.extend({
 				const container = this.$refs.container as HTMLElement
 				container.removeEventListener(`scroll`, this.handleScroll)
 			}
-			if (posts.length === 0 && this.currentOffset > 10) {
+			if (posts.length < this.limit && posts.length > 0) {
 				this.noMorePosts = true
 			}
 			this.isLoading = false


### PR DESCRIPTION
- [x]  “No more post” bug displayed even when there is no posts
- [x]  tag page have the loader + the “no posts” message + image, the message should only be displayed after loading
- [x]  z-index of close icon and select CTA of face selector is overlapping the popup header
- [x]  increase nuxt-link zone for the post card
- [x]  adjust stats bars in stat popup
- [x]  style new images pasted in post editor
- [x]  bug on little screens when sub category title doesn’t disappear on collapse
- [x]  bug collapsing
- [x]  display no comment message when filter