### PR TITLE
[fix] do not overlap pasted image by file picker button

### DIFF
--- a/src/components/post/Editor.vue
+++ b/src/components/post/Editor.vue
@@ -279,7 +279,10 @@ export default Vue.extend({
 					this.qeditor.insertEmbed(range.index, `image`, { alt: cid.toString(), url }, `user`)
 				}
 				const contentLength = this.qeditor.getContents().length()
-				setTimeout(() => this.qeditor?.setSelection(contentLength, 0, `user`), 0)
+				setTimeout(() => {
+					this.qeditor?.setSelection(contentLength, 0, `user`)
+					this.calculateAddPos(contentLength)
+				}, 0)
 			} catch (error: any) {
 				this.$toastError(error.message)
 			}


### PR DESCRIPTION
Calculate positions for the file picker button after pasting the content.

closes #409