### PR TITLE
fix: added missing 3 positive faces to positive feelings

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -358,6 +358,9 @@ export const feelings = {
 		`proud`,
 		`admiration`,
 		`awe`,
+		`determined`,
+		`defiant`,
+		`on_it`,
 	]),
 	negative: new Set([
 		`distracted`,


### PR DESCRIPTION
The reason for some faces not being taken into account into the total number of _positive, negative, neutral_ reactions is because the following three faces were not present in the positive array:
```
`determined`,
`defiant`,
`on_it`,
```

In order for these to be visible in the **Positive** filter, I make a call to:
```
// Get a list of comments with multiple emotions under the same category
this.comments = await getCommentsOfPost(this.postCID, undefined, this.filter)
```
As of now, the `positive` value of this.filter does not return the three emotions listed above. Can these please be added to the backend so they can be returned with the other positive comments? The call to retrieve these individually using the comment filter works fine, the only issue is adding these three reactions to the list of **Positive** comments.

Thanks!