### PR TITLE
fix: undefined tab title

### DIFF
--- a/src/pages/post/_post.vue
+++ b/src/pages/post/_post.vue
@@ -288,7 +288,7 @@ export default Vue.extend({
 	head() {
 		return {
 			// @ts-ignore
-			title: `${this.post?.title} by ${this.post?.authorID} on Blogchain`,
+			title: this.post ? `${this.post.title} by ${this.post.authorID} on Blogchain` : `Loading...`,
 			meta: [
 				{
 					hid: `post - ${this.$route.params.post}`,


### PR DESCRIPTION
Show `Loading...` text when the post is loading instead of showing `undefined by undefined...`