### PR TITLE
Revert "fix: temporarily update NEAR RPC url (#688)"

### DIFF
--- a/src/backend/near.ts
+++ b/src/backend/near.ts
@@ -29,7 +29,7 @@ function getRpcProviderUrl() {
 		case `mainnet`:
 		case `testnet`:
 		case `betanet`:
-			return `https://public-rpc.blockpi.io/http/near-testnet`
+			return `https://rpc.${nearConfig.networkId}.near.org`
 		case `local`:
 			return nearConfig.nodeUrl
 		default:

--- a/src/backend/utilities/config.ts
+++ b/src/backend/utilities/config.ts
@@ -58,7 +58,7 @@ export function getNearConfig(): INearConfig | ILocalNetNearConfig {
 		case `testnet`:
 			return {
 				networkId: `testnet`,
-				nodeUrl: `https://public-rpc.blockpi.io/http/near-testnet`,
+				nodeUrl: `https://rpc.testnet.near.org`,
 				contractName,
 				walletUrl: `https://wallet.testnet.near.org`,
 				helperUrl: `https://helper.testnet.near.org`,


### PR DESCRIPTION
This reverts commit d1a2106233d59d86cd0aae2c09cf5e7919727982.