### PR TITLE
perf: disable libp2p peerstore persistence

### DIFF
--- a/src/backend/utilities/ipfs.ts
+++ b/src/backend/utilities/ipfs.ts
@@ -12,6 +12,9 @@ export interface IPFSInterface {
 
 const ipfsConfig: Options = {
 	start: false,
+	libp2p: {
+		peerStore: { persistence: false },
+	},
 	init: { algorithm: `Ed25519` },
 	preload: {
 		enabled: false,


### PR DESCRIPTION
Basically IPFS (actually libp2p) saves already discovered peers into the PeerStore. And then each time IPFS starts, it retrieves the peers from there and tries to connect to them.

This apparently takes a **long** time. The more peers discovered, the more time it takes. And given that we already have a bunch of specified bootstrap nodes that include the full content, we don't need to remember the peers we have discovered in the past. So we can disable the peerStore completely!

In my network/computer this shaved off at least 1.75s (but I think it was more, because some more subsequent operations were accelerated too afterwards!)