### PR TITLE
fix: align post image to center

### DIFF
--- a/src/components/IpfsImage.vue
+++ b/src/components/IpfsImage.vue
@@ -56,7 +56,7 @@ export default Vue.extend({
 	display: block;
 	margin-left: auto;
 	margin-right: auto;
-	width: 50%;
+	width: 100%;
 	margin-top: 10px;
 	margin-bottom: 10px;
 }


### PR DESCRIPTION
- Added `ipfs-image` class to align post image to center
- Applied top and bottom margin to post image for better space between images