### PR TITLE
fix: disallow css styles in posts

### DIFF
--- a/src/components/PostView.vue
+++ b/src/components/PostView.vue
@@ -37,6 +37,8 @@ function sanitizeHTML(input: string) {
 		USE_PROFILES: { html: true },
 		ALLOWED_TAGS: [`pre`],
 		ADD_ATTR: [`cid`],
+		FORBID_ATTR: [`style`],
+		FORBID_TAGS: [`style`],
 	})
 }
 


### PR DESCRIPTION
This should mitigate the CSS injection vulnerability (**CAP-02-026 WP1: Insufficient HTML sanitation of Post Content (High)**)