### PR TITLE
fix: verification of encrypted posts

### DIFF
--- a/src/backend/post.ts
+++ b/src/backend/post.ts
@@ -254,13 +254,13 @@ export async function getOnePost(cid: string, bookmarker: string): Promise<IPost
 	return res.data.data
 }
 
-export async function verifyPostAuthenticity(content: ISignedIPFSObject<Post>) {
+export async function verifyPostAuthenticity(post: Post, sig: string, publicKey: string) {
 	try {
-		const { publicKey } = await getUserInfoNEAR(content.data.authorID)
-		if (uint8ArrayToHexString(publicKey) !== content.public_key) {
+		const { publicKey: contractPubKey } = await getUserInfoNEAR(post.authorID)
+		if (uint8ArrayToHexString(contractPubKey) !== publicKey) {
 			return false
 		}
-		const verified = verifyContent(content.data, hexStringToUint8Array(content.sig), publicKey)
+		const verified = verifyContent(post, hexStringToUint8Array(sig), contractPubKey)
 		return verified
 	} catch (err: any) {
 		return false

--- a/src/pages/post/_post.vue
+++ b/src/pages/post/_post.vue
@@ -413,7 +413,7 @@ export default Vue.extend({
 
 		// Using spread operator so that post.data.content getting
 		// assigned before signature verification doesn't affect it
-		verifyPostAuthenticity({ ...post }).then((verified) => {
+		verifyPostAuthenticity({ ...post.data }, post.sig, post.public_key).then((verified) => {
 			if (!verified) {
 				this.$toastError(`Post not verified!`)
 			}


### PR DESCRIPTION
We were asynchronously verifying the authenticity of the post, but it fails for encrypted posts because a post content gets decrypted and it modifies the post object, even though decryption happens after the verification. 

I figured this out last time and used a spread operator to solve this issue, and it seemed to work as I was using payments.capsule.social/server and there was some delay b/w post verification and actual decryption. However, today I found out since `ISignedIPFSObject<Post>` (`data`, `sig`, `public_key` being its properties) has nested objects, this is not sufficient. 

This PR fixes the issue of failed verification of encrypted posts