### PR TITLE
fix: do not send username when subscribing

### DIFF
--- a/src/backend/payment.ts
+++ b/src/backend/payment.ts
@@ -37,7 +37,6 @@ export async function startSubscriptionPayment(
 export async function confirmSubscriptionPayment(username: string, paymentAttemptId: string, paymentIntentId: string) {
 	try {
 		const data = {
-			username,
 			paymentAttemptId,
 			paymentIntentId,
 		}


### PR DESCRIPTION
When I try to subscribe to an author (latest premium-subscriptions branch, commit hash: a95a68c), capsule-server throws an error: "At path: username -- Expected a value of type never, but received: "testing2fren"". This is probably because capsule-vue still sends `username` in post body of `/pay/stripe/subscription/start`, a property that has been removed from the `StartSubscriptionRequest` superstruct validation since the token-auth merge. 

I removed username  from the POST request body and the subscription went through.