### PR TITLE
fix: funds transfer status route

### DIFF
--- a/src/backend/funder.ts
+++ b/src/backend/funder.ts
@@ -10,7 +10,7 @@ export async function requestOTP(phoneNumber: string) {
 }
 
 export async function getFundTransferStatus(accountId: string): Promise<`PROCESSING` | `SENT` | `FAILED`> {
-	const response = await axios.get(`${capsuleServer}/status?accountId=${accountId}`)
+	const response = await axios.get(`${capsuleServer}/sponsor/status?accountId=${accountId}`)
 	return response.data.data
 }
 


### PR DESCRIPTION
Correct route for getting the status of funds transfer is `/sponsor/status` and not `/status`