### PR TITLE
feat: add granural ipfs feedback depending on init state

### DIFF
--- a/src/components/Nodes.vue
+++ b/src/components/Nodes.vue
@@ -6,7 +6,13 @@
 			@mouseenter="showInfo = true"
 			@mouseleave="showInfo = false"
 		>
-			<span v-if="initIPFS" class="text-gray5 dark:text-gray1 mr-1 text-sm modal-animation">Initialising IPFS...</span>
+			<span v-if="loadingIPFS" class="text-gray5 dark:text-gray1 mr-1 text-sm modal-animation">Loading IPFS...</span>
+			<span v-else-if="initIPFS" class="text-gray5 dark:text-gray1 mr-1 text-sm modal-animation"
+				>Initialising IPFS...</span
+			>
+			<span v-else-if="startIPFS" class="text-gray5 dark:text-gray1 mr-1 text-sm modal-animation"
+				>Starting IPFS...</span
+			>
 			<span v-else-if="initNodes" class="text-gray5 dark:text-gray1 mr-1 text-sm modal-animation"
 				>Connecting to peers...</span
 			>
@@ -47,6 +53,8 @@ import ipfs from '@/backend/utilities/ipfs'
 export interface IData {
 	nodes: number
 	initNodes: boolean
+	loadingIPFS: boolean
+	startIPFS: boolean
 	initIPFS: boolean
 	showInfo: boolean
 }
@@ -59,13 +67,23 @@ export default Vue.extend({
 		return {
 			nodes: 0,
 			initNodes: true,
-			initIPFS: true,
+			startIPFS: false,
+			initIPFS: false,
+			loadingIPFS: true,
 			showInfo: false,
 		}
 	},
-	created() {
-		ipfs().initResult.then(async () => {
+	async created() {
+		await ipfs().loadingResult
+		this.loadingIPFS = false
+		this.initIPFS = true
+		await ipfs().initResult
+		this.startIPFS = true
+		this.initIPFS = false
+		ipfs().startResult.then(async () => {
+			this.startIPFS = false
 			this.initIPFS = false
+			this.loadingIPFS = false
 			await this.update()
 			this.updateLoop()
 		})


### PR DESCRIPTION
This PR adds feedback to the user informing of exactly the step that the IPFS initialisation is at. 

Steps are: 

1. Loading IPFS (the IPFS library is been downloaded - this step might take more time on slow connections)
2. Initialising IPFS (the IPFS repo is created - things could fail here on older browsers)
3. Starting IPFS (this will usually be really fast and users won't notice it - if it's noticed it will be that something is particularly slow or there's an error happening)
4. Connecting to peers (this step might take an infinite amount of time if the user has connection issues/unstable connection/not able to connect to peers)
5. {{ number of nodes }} peered nodes (things run nominally)