### PR TITLE
fix: copy testnet keystore only on mainnet

### DIFF
--- a/src/plugins/backend.ts
+++ b/src/plugins/backend.ts
@@ -2,11 +2,13 @@ import { Plugin } from '@nuxt/types'
 import { initIPFS } from '@/backend/utilities/ipfs'
 import { initLibSodium } from '@/backend/utilities/keys'
 import { initContract, initNear, initWalletConnection } from '@/backend/near'
+import { nearNetwork } from '@/backend/utilities/config'
 
 const backend: Plugin = async (context) => {
 	try {
 		// If the user has refreshed or backtracked etc
-		for (let i = 0; i < localStorage.length; i++) {
+		// eslint-disable-next-line no-unmodified-loop-condition
+		for (let i = 0; i < localStorage.length && nearNetwork === `mainnet`; i++) {
 			const key = localStorage.key(i)
 			if (key && key.startsWith(`near-api-js:keystore`)) {
 				if (key.endsWith(`testnet`)) {


### PR DESCRIPTION
As of now, keystore on alpha and payments also gets copied to mainnet. This PR makes sure that we copy the keystore only when on mainnet. 