### PR TITLE
ci: use github user + token from secrets

### DIFF
--- a/.github/workflows/check-push.yml
+++ b/.github/workflows/check-push.yml
@@ -3,9 +3,6 @@ on:
   push:
     branches:
       - '**'
-env:
-  GITHUB_USER: dgrisham
-  GITHUB_TOKEN: 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
 
 jobs:
 

--- a/.github/workflows/ci-release-development.yml
+++ b/.github/workflows/ci-release-development.yml
@@ -4,9 +4,6 @@ on:
     tags:
       - alpha
       - payments
-env:
-  GITHUB_USER: dgrisham
-  GITHUB_TOKEN: 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
 
 jobs:
 
@@ -108,7 +105,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           artifacts:    ${{ env.BUILD_NAME }}.tar.gz
-          token:        ${{ secrets.GITHUB_TOKEN }}
+          token:        ${{ secrets.GITREPO_TOKEN }}
           allowUpdates: true
 
   deploy:
@@ -141,6 +138,6 @@ jobs:
           DEPLOY_ENV:          ${{ env.DEPLOY_ENV }}
           RELEASE_ID:          ${{ env.RELEASE_ID }}
           RELEASE_TAG:         ${{ env.RELEASE_TAG }}
-          GITHUB_USER:         ${{ env.GITHUB_USER }}
-          GITHUB_TOKEN:        ${{ env.GITHUB_TOKEN }}
+          GITHUB_USER:         ${{ secrets.GITREPO_USER }}
+          GITHUB_TOKEN:        ${{ secrets.GITREPO_TOKEN }}
           ANSIBLE_PRIVATE_KEY: ${{ secrets.ANSIBLE_PRIVATE_KEY }}

--- a/.github/workflows/ci-release-production.yml
+++ b/.github/workflows/ci-release-production.yml
@@ -3,8 +3,6 @@ on:
   release:
     types: [published]
 env:
-  GITHUB_USER: dgrisham
-  GITHUB_TOKEN: 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
   DEPLOY_ENV: production
 
 jobs:
@@ -103,7 +101,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           artifacts:    ${{ env.BUILD_NAME }}.tar.gz
-          token:        ${{ secrets.GITHUB_TOKEN }}
+          token:        ${{ secrets.GITREPO_TOKEN }}
           allowUpdates: true
 
   deploy:
@@ -135,6 +133,6 @@ jobs:
           DEPLOY_ENV:          ${{ env.DEPLOY_ENV }}
           RELEASE_ID:          ${{ env.RELEASE_ID }}
           RELEASE_TAG:         ${{ env.RELEASE_TAG }}
-          GITHUB_USER:         ${{ env.GITHUB_USER }}
-          GITHUB_TOKEN:        ${{ env.GITHUB_TOKEN }}
+          GITHUB_USER:         ${{ secrets.GITREPO_USER }}
+          GITHUB_TOKEN:        ${{ secrets.GITREPO_TOKEN }}
           ANSIBLE_PRIVATE_KEY: ${{ secrets.ANSIBLE_PRIVATE_KEY }}


### PR DESCRIPTION
This removes the hardcoded Github credentials in favor of the ones stored in our Github secrets. This can be merged whenever, but this repo should not go public until I've made the same change on all of the other repos and revoked the token (since it'll still be in the git history).