### PR TITLE
fix: consistent length count for long bio + trim long bios before dis…

### DIFF
--- a/src/pages/id/_id.vue
+++ b/src/pages/id/_id.vue
@@ -461,7 +461,7 @@ export default Vue.extend({
 				container.addEventListener(`scroll`, this.handleScrollHeader)
 			}
 			// handle long bios
-			if (this.visitProfile && this.visitProfile.bio.length > 200) {
+			if (this.visitProfile && this.visitProfile.bio.trim().length > 200) {
 				this.longBio = true
 			}
 		},

--- a/src/pages/id/_id.vue
+++ b/src/pages/id/_id.vue
@@ -179,7 +179,7 @@
 				class="header-profile px-1 pt-4 dark:text-darkPrimaryText"
 				:style="expandBio ? `` : `max-height: 5.5rem; overflow: hidden`"
 			>
-				<p>{{ visitProfile.bio.slice(0, 200) + (visitProfile.bio.length > 200 ? '...' : '') }}<br /></p>
+				<p>{{ visitProfile.bio.trim().slice(0, 200) + (visitProfile.bio.trim().length > 200 ? '...' : '') }}<br /></p>
 			</div>
 			<button
 				v-show="longBio"
@@ -461,7 +461,7 @@ export default Vue.extend({
 				container.addEventListener(`scroll`, this.handleScrollHeader)
 			}
 			// handle long bios
-			if (this.visitProfile && this.visitProfile.bio.length > 150) {
+			if (this.visitProfile && this.visitProfile.bio.length > 200) {
 				this.longBio = true
 			}
 		},


### PR DESCRIPTION
It happened that we didn't use consistent length for long bio when calculating and displaying `read more`